### PR TITLE
Add auto-merge workflow with 30-minute schedule

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,50 @@
+name: Automerge
+
+on:
+  push:
+  schedule:
+    - cron: '0,30 * * * *'
+
+  # Enable auto-merge when a pull request review is submitted.
+  pull_request_review:
+    types:
+      - submitted
+
+  # Enable auto-merge when a draft is marked as ready for review,
+  # a required label is applied, a "do not merge" label is removed,
+  # or when the pull request is updated.
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+  # Manually trigger auto-merge for a specific pull request or review via workflow dispatch.
+  workflow_dispatch:
+    inputs:
+      pull-request:
+        description: Pull Request Number (optional)
+        required: false
+      review:
+        description: Review ID (optional)
+        required: false
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-Merge Pull Request
+        uses: reitermarkus/automerge@v2
+        with:
+          token: ${{ secrets.github_token }}
+          merge-method: rebase
+          do-not-merge-labels: never-merge
+          required-labels: automerge
+          pull-request: ${{ github.event.inputs.pull-request }}
+          review: ${{ github.event.inputs.review }}
+          dry-run: false
+

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Auto-Merge Pull Request
         uses: reitermarkus/automerge@v2
         with:
-          token: ${{ secrets.github_token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: rebase
           do-not-merge-labels: never-merge
           required-labels: automerge


### PR DESCRIPTION
- Introduced a GitHub Actions workflow to automate merging of approved pull requests.
- Configured the workflow to run every 30 minutes using cron expression '0,30 * * * *'.
- Enabled auto-merge on pull request review submissions and updates.
- Added manual trigger support for specific pull requests and reviews via workflow dispatch.
- Set up the workflow to use 'rebase' merge method and handle auto-merge and "do not merge" labels.

This initial setup ensures automated handling of pull requests based on review status and labels.