### PR TITLE
feat(ansible): enhance configuration for Docker and other services

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -6,3 +6,4 @@ ansible_become = yes
 ansible_become_method = sudo
 interpreter_python= '/usr/bin/python3'
 ansible_python_interpreter = '/usr/bin/env python3'
+host_key_checking = False

--- a/ansible/configure_nfs.yaml
+++ b/ansible/configure_nfs.yaml
@@ -1,3 +1,4 @@
+---
 - name: Retrieve UUID from the attached filesystems
   ansible.builtin.shell:
     cmd: blkid | grep sda | awk -F '\"' '{print $2}'
@@ -20,20 +21,18 @@
     name: nfs-kernel-server
     state: latest
 
-- name: Start nfs-server
-  ansible.builtin.service:
-    name: nfs-server
-    state: started
-    enabled: yes
-
 - name: Ensure required entries are made to hosts file
   ansible.builtin.lineinfile:
     path: /etc/exports
     line: "{{ item }}"
   loop:
     - "/mnt/data/       192.168.31.0/24(rw,sync,no_subtree_check)"
-  notify: Restart NFS service
+
+- name: Start nfs-server
+  ansible.builtin.service:
+    name: nfs-server
+    state: restarted
+    enabled: true
 
 - name: Ensure the directory is ready for NFS usages
   ansible.builtin.command: exportfs -rav
-

--- a/ansible/deploy_docker_containers.yaml
+++ b/ansible/deploy_docker_containers.yaml
@@ -1,45 +1,51 @@
 ---
 - name: Get Docker convenience script
+  become: true
   ansible.builtin.get_url:
     url: https://get.docker.com
-    dest: ~/get-docker.sh
+    dest: /root/get-docker.sh
     mode: '0755'
 
 - name: Check if Docker already installed
+  become: true
   ansible.builtin.command: dpkg-query -l docker
   register: package_check
   changed_when: false
   failed_when: false
 
 - name: Install Docker
-  ansible.builtin.command: sh /home/pi/get-docker.sh
+  become: true
+  ansible.builtin.command: sh /root/get-docker.sh
   args:
     creates: /usr/bin/docker
   when: package_check.rc != 0
 
 - name: Adding user pi to docker group
+  become: true
   ansible.builtin.user:
     name: pi
     groups: docker
     append: yes
-  become: true
+
+- name: Upgrade pip
+  ansible.builtin.pip:
+    name: pip
+    extra_args: --upgrade
+    executable: pip3
 
 - name: Install pip packages
   ansible.builtin.pip:
-    name: "{{ item }}"
-  loop:
-    - docker-compose
-    - ansible
-    - docker
-  become: true
-  executable: pip3
+    name: "docker-compose ansible docker"
+    extra_args: --no-build-isolation --break-system-packages
+    executable: pip3
 
 - name: Clone GitHub repository
   ansible.builtin.git:
     repo: git@github.com:dpinhas/rpi-media-server.git
-    dest: /home/pi/rpi-media-server
+    dest: /home/pi/rpi-media-server/
     clone: yes
     update: yes
+    version: main
 
 - name: Add DATA_PATH var to bashrc
   ansible.builtin.lineinfile:
@@ -49,33 +55,14 @@
     create: yes
     insertafter: EOF
 
-- name: Deploy cronjob
-  ansible.builtin.copy:
-    src: '../scripts/update_ddns_records'
-    dest: '/etc/cron.hourly'
-    mode: '0755'
-  become: true
-  when: inventory_hostname == 'pi0'
-
 - name: Deploy containers and services - docker-compose (pi0)
   ansible.builtin.command:
-    cmd: "docker-compose up -d"
-    chdir: /home/pi/rpi-media-server/docker
+    cmd: "make docker_start"
+    chdir: /home/pi/rpi-media-server
   register: docker_compose_output
   changed_when: docker_compose_output.stdout != ''
   failed_when: docker_compose_output.stdout != ''
-  when: inventory_hostname == 'pi0'
-
-- name: Deploy containers and services - docker-compose (pi1)
-  ansible.builtin.command:
-    cmd: "docker-compose up -d"
-    chdir: /home/pi/rpi-media-server/monitoring
-  register: docker_compose_output
-  changed_when: docker_compose_output.stdout != ''
-  failed_when: docker_compose_output.stdout != ''
-  when: inventory_hostname == 'pi1'
 
 - name: Display output
   ansible.builtin.debug:
     var: docker_compose_output
-

--- a/ansible/main.yaml
+++ b/ansible/main.yaml
@@ -25,4 +25,3 @@
     - name: Include Docker Deployment Tasks
       ansible.builtin.include_tasks: deploy_docker_containers.yaml
       when: deploy_docker_containers | bool
-

--- a/config/ping_exporter.yml
+++ b/config/ping_exporter.yml
@@ -6,7 +6,6 @@ targets:
   - 192.168.31.1
   - 192.168.31.10
   - play.dpinhas.duckdns.org
-  - play.dpinhas-public.duckdns.org
 
 dns:
   refresh: 2m15s

--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -67,7 +67,6 @@ scrape_configs:
         - https://grafana.dpinhas.duckdns.org
         - https://download.dpinhas.duckdns.org
         - https://adguard.dpinhas.duckdns.org
-        - https://play.dpinhas-public.duckdns.org
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -85,7 +84,7 @@ scrape_configs:
       - targets: ['8.8.8.8', '8.8.4.4', '1.1.1.1', '1.0.0.1', '194.90.0.1']
         labels:
           group: 'external_network'
-      - targets: ['192.168.31.1', '192.168.31.10', '10.100.102.1']
+      - targets: ['192.168.31.1', '192.168.31.10']
         labels:
           group: 'internal_network'
     relabel_configs:

--- a/config/traefik/dynamic.yaml
+++ b/config/traefik/dynamic.yaml
@@ -3,28 +3,28 @@ http:
     grafana:
       rule: "Host(`grafana.dpinhas.duckdns.org`)"
       service: grafana
-      entrypoints: 
+      entrypoints:
         - "web-secure"
       tls:
         certResolver: myresolver
     prometheus:
       rule: "Host(`prometheus.dpinhas.duckdns.org`)"
       service: prometheus
-      entrypoints: 
+      entrypoints:
         - "web-secure"
       tls:
         certResolver: myresolver
     blackbox:
       rule: "Host(`blackbox.dpinhas.duckdns.org`)"
       service: blackbox
-      entrypoints: 
+      entrypoints:
         - "web-secure"
       tls:
         certResolver: myresolver
     homebridge:
       rule: "Host(`homebridge.dpinhas.duckdns.org`)"
       service: homebridge
-      entrypoints: 
+      entrypoints:
         - "web-secure"
       tls:
         certResolver: myresolver

--- a/docker/services.yaml
+++ b/docker/services.yaml
@@ -113,3 +113,21 @@ services:
     command:
       - "tailscaled"
     restart: unless-stopped
+
+  node-exporter:
+    image: prom/node-exporter:${NODE_EXPORTER_TAG}
+    container_name: node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+      - /mnt/data:/mnt/data:ro
+      - ${PWD}/../config/custom_metrics/:/custom_metrics
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.textfile.directory=/custom_metrics/'
+      - '--collector.tcpstat'
+    restart: unless-stopped
+    ports:
+      - "${NODE_EXPORTER_PORT}:9100"


### PR DESCRIPTION
- Disable host key checking in Ansible configuration
- Modify `configure_nfs.yaml` to restart `nfs-server` and update hosts file entries
- Refine `deploy_docker_containers.yaml`:
- Adjust Docker install path and permissions
- Add `become` directive for relevant tasks - Update pip package installation and clone repository with specified branch - Replace docker-compose command with `make docker_start`
- Remove outdated target entries from `ping_exporter.yml` and `prometheus.yml`
- Clean up entrypoint syntax in `traefik/dynamic.yaml`
- Add Node Exporter service in `docker/services.yaml` with host metrics configuration